### PR TITLE
Update nexus release textbox details

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseAction/index.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/m2release/M2ReleaseAction/index.jelly
@@ -44,7 +44,7 @@
 
 					<j:if test="${it.nexusSupportEnabled}">
 						<f:section title="Nexus Pro Support">
-							<f:optionalBlock name="closeNexusStage" title="Close Nexus Staging Repository" checked="true">
+							<f:optionalBlock name="closeNexusStage" title="Close and Release Nexus Staging Repository (Uncheck for releases that require voting)" checked="true">
 							<f:entry title="Repository Description">
 								<f:textbox name="repoDescription" value="${it.computeRepoDescription()}" />
 							</f:entry>


### PR DESCRIPTION
## Purpose
Update nexus release textbox details

## Goals
Reduce mistakes make by people when they manually trigger releases via Jenkins.

## Approach
`s/Close Nexus Staging Repository/Close and Release Nexus Staging Repository (Uncheck for releases that require voting)/g`
## User stories
> Summary of user stories addressed by this change>
